### PR TITLE
增加一个option，支持可以设定生成的模板路径

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ grunt.initConfig({
 
 输出文档 HTML 文件路径。
 
+#### options.templateFilePath
+
+- Typs: `String`
+- Default value: `''`
+
+文档模板地址，如果为空字符串，则使用grunt-react-docgen默认的地址（默认模板插件自行维护）
+
 ## 版本历史
 
 - [0.1.0]

--- a/tasks/react_docgen.js
+++ b/tasks/react_docgen.js
@@ -237,8 +237,8 @@ module.exports = function (grunt) {
         tplSource = fs.readFileSync(options.templateFilePath, 'utf-8');
       }
     } catch (e) {
-      grunt.log.writeln('"templateFilePath" is being set while it is invalid. Check your templateFilePath value to ensure the path is correct'.red);
-      grunt.log.error(e);
+      grunt.log.warn('"templateFilePath" is being set but it is invalid. Checkout your templateFilePath value to ensure the path is correct'.yellow);
+      grunt.log.warn('grunt-react-docgen will use default template to bulid'.yellow);
       tplSource = '';
     }
     

--- a/tasks/react_docgen.js
+++ b/tasks/react_docgen.js
@@ -230,7 +230,19 @@ module.exports = function (grunt) {
 
     grunt.verbose.writeln(JSON.stringify(fileDocMetaArr, null, 2));
 
-    grunt.file.write(options.outputFilePath, Juicer(DOC_TPL_SOURCE, {
+    // Use templateFilePath to change default jucier template path when templateFilePath is valid.
+    var tplSource = '';
+    try {
+      if (options.templateFilePath) {
+        tplSource = fs.readFileSync(options.templateFilePath, 'utf-8');
+      }
+    } catch (e) {
+      grunt.log.writeln('"templateFilePath" is being set while it is invalid. Check your templateFilePath value to ensure the path is correct'.red);
+      grunt.log.error(e);
+      tplSource = '';
+    }
+    
+    grunt.file.write(options.outputFilePath, Juicer((tplSource || DOC_TPL_SOURCE), {
       name: pkgInfo.name,
       description: pkgInfo.description,
       version: pkgInfo.version,


### PR DESCRIPTION
增加：templateFilePath，使得插件可以支持自定义生成demo的模板路径。如果路径无效，则使用原来默认的内部模板